### PR TITLE
Added the option to clear the existing devices in the discover method so the whole scan process can start again from the begining.

### DIFF
--- a/lib/miflora.js
+++ b/lib/miflora.js
@@ -39,7 +39,12 @@ class MiFlora {
 		const optDuration = getOpt(options, 'duration', 10000);
 		const optAddresses = getOpt(options, 'addresses', []);
 		const optIgnoreUnknown = getOpt(options, 'ignoreUnknown', false);
-
+		const clearDevices = getOpt(options, 'clearDevices', false);
+		
+		if (clearDevices) {
+			this._devices = {};	
+		}
+		
 		if (Number.isNaN(optDuration)) {
 			throw new TypeError('argument [duration] must be a number');
 		}


### PR DESCRIPTION
I was attempting to use miflora in a custom node in node-red. When it re-deploys a node it will re-run all the code and I was having trouble tearing down the miflora connection and it would break on each deploy until I restarted node-red. I discovered this was due to the main miflora devices object was not reset between calls to the `discover` method so the same device was never discovered again and it seemed to break things. This commit hopefully solves that. Here is some code demonstrating the problem: 

```
const miflora = require('miflora');
const opts = { 
    duration: 60000, 
    ignoreUnknown: true, 
    addresses: ['c4:7c:8d:66:23:b5']
};
(async () => {
        console.log('attempt 1')
        let device = (await miflora.discover(opts))[0];
        await device.querySensorValues();
        await device.disconnect();
        console.log('done attempt 1');

        miflora._devices = {}; // Without this line the below would fail to find the device. 

        console.log('attempt 2')
        device = (await miflora.discover(opts))[0];
        await device.querySensorValues();
        await device.disconnect();
        console.log('done attempt 2');

})();

```

This PR adds an option `clearDevices` to the options passed to the discover method to that the above would become: 

```
const miflora = require('miflora');
const opts = { 
    duration: 60000, 
    ignoreUnknown: true, 
    clearDevices: true,
    addresses: ['c4:7c:8d:66:23:b5']
};
(async () => {
        console.log('attempt 1')
        let device = (await miflora.discover(opts))[0];
        await device.querySensorValues();
        await device.disconnect();
        console.log('done attempt 1');

        console.log('attempt 2')
        device = (await miflora.discover(opts))[0];
        await device.querySensorValues();
        await device.disconnect();
        console.log('done attempt 2');

})();

```

Thank you!