### PR TITLE
feat: VegTrug Grow Care Garden (GCLS002) support

### DIFF
--- a/lib/miflora-device.js
+++ b/lib/miflora-device.js
@@ -335,6 +335,8 @@ class MiFloraDevice {
 				switch (productId) {
 					case 0x98:
 						return new MiFloraDevice(peripheral, 'MiFloraMonitor');
+					case 0x03BC: // VegTrug Grow Care Garden (GCLS002) | Flower Care Max
+						return new MiFloraDevice(peripheral, 'MiFloraMonitor');
 					case 0x015D:
 						return new MiFloraDevice(peripheral, 'MiFloraPot');
 					default:


### PR DESCRIPTION
VegTrug Grow Care Garden (GCLS002) aka Flower Care Max is a product similar to Flower Care and it is identified with a different productId. This commit change provides underlying support for this device.